### PR TITLE
Add color-based ingredient recognition endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,22 @@ A production-ready cooking assistant platform that makes cooking accessible and 
 
 ### **1. VPS Security Setup (CRITICAL FIRST STEP)**
 
-Run the security setup script to create a non-root user and secure your VPS:
+Run the security setup script to create a non-root user and secure your VPS.
+Ensure PostgreSQL is installed and running on the VPS (the script installs it
+if missing). Confirm you can connect before moving on.
+
+> **Where are the scripts?** The `scripts/` directory isn't included in this
+> repository.
+> **Option A (recommended)**: clone the helper scripts from
+> [chefito-scripts](https://github.com/soofmaax/chefito-scripts) and copy the
+> folder next to this project.
+> **Option B**: manually create the scripts using the examples in
+> `scripts_content.md`.
 
 ```bash
+# Clone the helper scripts if you haven't already
+git clone https://github.com/soofmaax/chefito-scripts.git scripts
+
 # Make the script executable
 chmod +x scripts/setup_vps_security.sh
 
@@ -70,9 +83,11 @@ This script will:
 
 ### **2. Automated Recipe Pipeline**
 
-Use the enhanced pipeline script to manage 30+ recipes automatically:
-
+Use the enhanced pipeline script to manage 30+ recipes automatically. If you
+don't yet have the `scripts/` folder, clone it now:
 ```bash
+git clone https://github.com/soofmaax/chefito-scripts.git scripts
+
 # Make the script executable
 chmod +x scripts/run_recipe_pipeline.sh
 
@@ -136,6 +151,19 @@ OLLAMA_MODEL=llama3:8b-instruct-q4_K_M
 # RevenueCat (Optional - for subscriptions)
 NEXT_PUBLIC_REVENUECAT_API_KEY=your_revenuecat_public_api_key
 ```
+
+Copy `.env.example` to `.env` and update these PostgreSQL variables for local
+development. Define the same variables on your VPS or Netlify to allow the
+backend to connect to your database.
+
+### **4. Database Setup**
+
+1. Ensure your PostgreSQL service is running and accessible.
+2. Apply database migrations:
+   ```bash
+   alembic upgrade head
+   ```
+   (See `alembic_instructions.txt` for full setup details.)
 
 ## 📡 **API Architecture**
 
@@ -288,6 +316,23 @@ AI: "For step 3 of your fried rice recipe, if the rice is sticky,
 - **Context caching**: Recipe context cached per session
 - **Streaming responses**: Real-time AI response delivery
 - **Fallback responses**: Instant fallbacks when AI unavailable
+
+## 🧪 **Testing**
+
+Run the Python tests with **pytest** and the Flutter tests with **dart test**.
+
+```bash
+# install Python dependencies
+pip install -r requirements.txt
+
+pytest -q
+
+# fetch Dart packages
+flutter pub get
+dart test
+```
+
+Ensure all dependencies (FastAPI, Pydantic, SQLAlchemy, etc.) and the Flutter SDK are installed before running the commands.
 
 ## 👥 **About the Creator**
 

--- a/alembic_instructions.txt
+++ b/alembic_instructions.txt
@@ -1,0 +1,25 @@
+# Alembic Setup
+
+1. Initialize Alembic in your project root:
+   ```bash
+   alembic init alembic
+   ```
+
+2. Edit `alembic.ini` to set the `sqlalchemy.url` with the same DATABASE_URL as in `.env`.
+
+3. In `alembic/env.py`, import `Base` and the SQLAlchemy models:
+   ```python
+   from app.database import engine, Base
+   from app import models  # ensures models are registered
+   target_metadata = Base.metadata
+   ```
+
+4. Generate the first migration:
+   ```bash
+   alembic revision --autogenerate -m "create recipe tables"
+   ```
+
+5. Apply migrations:
+   ```bash
+   alembic upgrade head
+   ```

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,31 @@
+import logging
+from fastapi import FastAPI, Request, HTTPException
+from fastapi.responses import JSONResponse
+
+from .recipes_semantic import router as recipes_router
+from .ingredient_recognition_semantic import router as ingredients_router
+from .ingredient_recognition import router as simple_recognition_router
+from .recipe_adaptation_semantic import router as adaptation_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+
+    app.include_router(recipes_router)
+    app.include_router(ingredients_router)
+    app.include_router(simple_recognition_router)
+    app.include_router(adaptation_router)
+
+    logger = logging.getLogger("chefito.api")
+
+    @app.exception_handler(HTTPException)
+    async def http_exception_handler(request: Request, exc: HTTPException):
+        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
+    @app.exception_handler(Exception)
+    async def unhandled_exception_handler(request: Request, exc: Exception):
+        logger.exception("Unhandled error: %s", exc)
+        return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
+
+    return app
+

--- a/app/api/ingredient_recognition.py
+++ b/app/api/ingredient_recognition.py
@@ -1,0 +1,89 @@
+from typing import List
+from io import BytesIO
+
+from fastapi import APIRouter, UploadFile, File, HTTPException
+from pydantic import BaseModel
+from PIL import Image
+
+
+router = APIRouter()
+
+
+class RecognizedItem(BaseModel):
+    name: str
+    confidence: float
+    visual_description: str
+    tactile_description: str
+    olfactory_description: str
+
+
+class RecognitionResponse(BaseModel):
+    recognized_items: List[RecognizedItem]
+
+
+COLOR_RULES = {
+    'red': {
+        'name': 'tomate',
+        'descriptions': (
+            'rouge et ronde',
+            'lisse et ferme',
+            'légèrement sucrée'
+        ),
+        'confidence': 0.8,
+    },
+    'orange': {
+        'name': 'carotte',
+        'descriptions': (
+            'orange et allongée',
+            'rugueuse',
+            'odeur terreuse'
+        ),
+        'confidence': 0.75,
+    },
+}
+
+
+def _dominant_color(image: Image.Image) -> str:
+    small = image.resize((1, 1))
+    r, g, b = small.getpixel((0, 0))
+    if r > 200 and g < 100 and b < 100:
+        return 'red'
+    if r > 200 and g > 100 and b < 50:
+        return 'orange'
+    return 'unknown'
+
+
+def recognize_ingredients_from_image(image_bytes: bytes) -> List[RecognizedItem]:
+    try:
+        img = Image.open(BytesIO(image_bytes)).convert('RGB')
+    except Exception:
+        raise HTTPException(status_code=422, detail='Invalid image file')
+
+    color = _dominant_color(img)
+    rule = COLOR_RULES.get(color)
+    if not rule:
+        return []
+
+    name = rule['name']
+    desc = rule['descriptions']
+    confidence = rule['confidence']
+    return [
+        RecognizedItem(
+            name=name,
+            confidence=confidence,
+            visual_description=desc[0],
+            tactile_description=desc[1],
+            olfactory_description=desc[2],
+        )
+    ]
+
+
+@router.post('/ingredients/recognize', response_model=RecognitionResponse)
+async def recognize_ingredients(file: UploadFile = File(...)):
+    if not file.content_type or not file.content_type.startswith('image/'):
+        raise HTTPException(status_code=415, detail='File must be an image')
+
+    data = await file.read()
+    items = recognize_ingredients_from_image(data)
+    return RecognitionResponse(recognized_items=items)
+

--- a/app/api/ingredient_recognition_semantic.py
+++ b/app/api/ingredient_recognition_semantic.py
@@ -1,0 +1,93 @@
+from typing import List
+from io import BytesIO
+
+import logging
+from fastapi import APIRouter, UploadFile, File, HTTPException
+from pydantic import BaseModel
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+class RecognizedItem(BaseModel):
+    name: str
+    confidence: float
+    visual_description: str
+    tactile_description: str
+    olfactory_description: str
+
+class RecognitionResponse(BaseModel):
+    recognized_items: List[RecognizedItem]
+
+
+def recognize_ingredients_from_image(image_bytes: bytes) -> List[RecognizedItem]:
+    """Attempt to recognize basic ingredients based on dominant color."""
+    color_db = {
+        'pomme': {
+            'rgb': (220, 0, 0),
+            'desc': ('pomme', 'rouge et ronde', 'lisse et ferme', 'légèrement sucrée'),
+        },
+        'carotte': {
+            'rgb': (255, 140, 0),
+            'desc': ('carotte', 'orange et allongée', 'rugueuse', 'odeur terreuse'),
+        },
+        'oeuf': {
+            'rgb': (245, 245, 220),
+            'desc': ('œuf', 'blanc et ovale', 'lisse', 'neutre'),
+        },
+        'farine': {
+            'rgb': (250, 250, 250),
+            'desc': ('farine', 'poudre blanche', 'poudreuse', 'neutre'),
+        },
+    }
+
+    try:
+        img = Image.open(BytesIO(image_bytes)).convert('RGB')
+    except Exception:
+        return []
+
+    # compute average color
+    avg_color = img.resize((1, 1)).getpixel((0, 0))
+
+    def color_distance(c1, c2):
+        return sum((a - b) ** 2 for a, b in zip(c1, c2)) ** 0.5
+
+    recognized: List[RecognizedItem] = []
+    max_dist = (3 * (255 ** 2)) ** 0.5
+    for info in color_db.values():
+        dist = color_distance(avg_color, info['rgb'])
+        confidence = max(0.0, 1 - dist / max_dist)
+        if confidence >= 0.8:
+            desc = info['desc']
+            recognized.append(
+                RecognizedItem(
+                    name=desc[0],
+                    confidence=round(confidence, 2),
+                    visual_description=desc[1],
+                    tactile_description=desc[2],
+                    olfactory_description=desc[3],
+                )
+            )
+
+    return recognized
+
+
+@router.post('/ingredients/recognize', response_model=RecognitionResponse)
+async def recognize_ingredients(file: UploadFile = File(...)):
+    if not file.content_type or not file.content_type.startswith('image/'):
+        raise HTTPException(status_code=415, detail='File must be an image')
+    try:
+        data = await file.read()
+        Image.open(BytesIO(data))
+    except Exception as exc:
+        logger.warning("invalid image upload: %s", exc)
+        raise HTTPException(status_code=422, detail='Invalid image file')
+
+    try:
+        items = recognize_ingredients_from_image(data)
+    except Exception as exc:
+        logger.exception("recognition failed: %s", exc)
+        raise HTTPException(status_code=500, detail='Recognition error')
+
+    return RecognitionResponse(recognized_items=items)

--- a/app/api/recipe_adaptation_semantic.py
+++ b/app/api/recipe_adaptation_semantic.py
@@ -1,0 +1,117 @@
+from typing import List
+import logging
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.models.recipe_semantic import Recipe
+from app.api.recipes_semantic import _mock_semantic_recipes_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+class AdaptationRequest(BaseModel):
+    constraint: str
+
+class AdaptedRecipeResponse(BaseModel):
+    original_recipe_id: str
+    constraint_applied: str
+    suggested_changes_text: List[str]
+    adapted_recipe: Recipe
+
+
+def _find_recipe(recipe_id: str) -> Recipe:
+    for r in _mock_semantic_recipes_db:
+        if r.recipe_id == recipe_id:
+            return r
+    raise HTTPException(status_code=404, detail="Recipe not found")
+
+
+def _adapt_no_eggs(recipe: Recipe) -> (Recipe, List[str]):
+    adapted = recipe.copy(deep=True)
+    suggestions = []
+    egg_found = False
+    for ing in adapted.ingredients:
+        if "oeuf" in ing.name.lower() or "egg" in ing.name.lower():
+            egg_found = True
+            suggestions.append(
+                f"Remplacez {ing.name} par un substitut d'oeuf (1/4 tasse de pur\u00e9e de banane ou 1 c.\u00e0s de graines de lin moulues + 3 c.\u00e0s d'eau). La texture pourrait \u00eatre l\u00e9g\u00e8rement diff\u00e9rente."
+            )
+            ing.name = "Substitut d'oeuf"
+    if egg_found:
+        for instr in adapted.instructions:
+            if "oeuf" in instr.details.lower() or "egg" in instr.details.lower():
+                instr.details = instr.details.replace("oeuf", "substitut d'oeuf").replace(
+                    "egg", "substitut d'oeuf"
+                )
+    else:
+        suggestions.append("Aucun oeuf trouv\u00e9 dans la recette.")
+    return adapted, suggestions
+
+
+def _adapt_no_oven(recipe: Recipe) -> (Recipe, List[str]):
+    adapted = recipe.copy(deep=True)
+    suggestions = []
+    changed = False
+    for instr in adapted.instructions:
+        if "four" in instr.action.lower() or "four" in instr.details.lower() or "oven" in instr.action.lower() or "oven" in instr.details.lower():
+            changed = True
+            suggestions.append(
+                f"Remplacez l\u00e9tape '{instr.action}' par une cuisson alternative \u00e0 la po\u00eale ou vapeur. La texture pourrait \u00eatre diff\u00e9rente."
+            )
+            instr.action = instr.action.replace("four", "cuisson alternative").replace(
+                "oven", "cuisson alternative"
+            )
+            instr.details = instr.details.replace("four", "po\u00eale").replace(
+                "oven", "po\u00eale"
+            )
+    if not changed:
+        suggestions.append("Aucune utilisation du four d\u00e9tect\u00e9e.")
+    return adapted, suggestions
+
+
+def _adapt_lactose_free(recipe: Recipe) -> (Recipe, List[str]):
+    adapted = recipe.copy(deep=True)
+    suggestions = []
+    dairy_terms = ["lait", "beurre", "cream", "cheese"]
+    changed = False
+    for ing in adapted.ingredients:
+        if ing.category.lower() == "dairy" or any(term in ing.name.lower() for term in dairy_terms):
+            changed = True
+            suggestions.append(
+                f"Remplacez {ing.name} par une alternative sans lactose (lait v\u00e9g\u00e9tal, margarine...). La saveur pourrait \u00eatre l\u00e9g\u00e8rement diff\u00e9rente."
+            )
+            ing.name = f"Substitut sans lactose pour {ing.name}"
+    if not changed:
+        suggestions.append("Aucun ingr\u00e9dient laitier d\u00e9tect\u00e9.")
+    return adapted, suggestions
+
+
+@router.post("/recipes/{recipe_id}/adapt", response_model=AdaptedRecipeResponse)
+def adapt_recipe(recipe_id: str, req: AdaptationRequest):
+    try:
+        recipe = _find_recipe(recipe_id)
+        constraint = req.constraint.lower()
+        if "oeuf" in constraint or "egg" in constraint:
+            adapted, suggestions = _adapt_no_eggs(recipe)
+            applied = "pas d'oeufs"
+        elif "four" in constraint or "oven" in constraint:
+            adapted, suggestions = _adapt_no_oven(recipe)
+            applied = "pas de four"
+        elif "lactose" in constraint:
+            adapted, suggestions = _adapt_lactose_free(recipe)
+            applied = "sans lactose"
+        else:
+            raise HTTPException(status_code=400, detail="Contrainte non reconnue")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("adaptation failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Adaptation error")
+
+    return AdaptedRecipeResponse(
+        original_recipe_id=recipe_id,
+        constraint_applied=applied,
+        suggested_changes_text=suggestions,
+        adapted_recipe=adapted,
+    )

--- a/app/api/recipes_semantic.py
+++ b/app/api/recipes_semantic.py
@@ -1,0 +1,175 @@
+from typing import List, Optional
+from uuid import uuid4
+
+import logging
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.models.recipe_semantic import (
+    Recipe,
+    Ingredient,
+    Instruction,
+    TroubleshootingTip,
+    StorageAndReheating,
+    SuccessMetrics,
+    RecipeDB,
+    IngredientDB,
+    InstructionDB,
+)
+from app.database import get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class RecipeCreate(BaseModel):
+    title: str
+    description: str
+    ingredients: List[Ingredient]
+    instructions: List[Instruction]
+    variations: List[str]
+    chef_guidance: List[str]
+    ai_conversation_prompts: List[str]
+    storage_and_reheating: StorageAndReheating
+    common_troubleshooting: List[TroubleshootingTip]
+    success_metrics: SuccessMetrics
+    prep_time_minutes: Optional[int] = None
+    cook_time_minutes: Optional[int] = None
+    servings: Optional[int] = None
+    tags: List[str]
+
+
+def convert_db_recipe(db_recipe: RecipeDB) -> Recipe:
+    ingredients = [
+        Ingredient(
+            id=str(i.id),
+            name=i.name,
+            quantity=i.quantity,
+            unit=i.unit,
+            category=i.category,
+            notes=i.notes,
+        )
+        for i in db_recipe.ingredients
+    ]
+
+    instructions = [
+        Instruction(
+            id=str(ins.id),
+            action=ins.action,
+            details=ins.details,
+            time_minutes=ins.time_minutes,
+            safety_warning=ins.safety_warning,
+            priority=ins.priority,
+            ingredients_used=[str(x) for x in (ins.ingredients_used or [])],
+            utensils_used=ins.utensils_used or [],
+            troubleshooting=[TroubleshootingTip(**t) for t in ins.troubleshooting or []],
+        )
+        for ins in db_recipe.instructions
+    ]
+
+    return Recipe(
+        recipe_id=str(db_recipe.recipe_id),
+        title=db_recipe.title,
+        description=db_recipe.description,
+        ingredients=ingredients,
+        instructions=instructions,
+        variations=db_recipe.variations or [],
+        chef_guidance=db_recipe.chef_guidance or [],
+        ai_conversation_prompts=db_recipe.ai_conversation_prompts or [],
+        storage_and_reheating=StorageAndReheating(**db_recipe.storage_and_reheating),
+        common_troubleshooting=[
+            TroubleshootingTip(**t) for t in db_recipe.common_troubleshooting or []
+        ],
+        success_metrics=SuccessMetrics(**db_recipe.success_metrics),
+        prep_time_minutes=db_recipe.prep_time_minutes,
+        cook_time_minutes=db_recipe.cook_time_minutes,
+        servings=db_recipe.servings,
+        tags=db_recipe.tags or [],
+    )
+
+
+@router.get("/recipes", response_model=List[Recipe])
+def list_recipes(
+    skip: int = 0, limit: int = 10, db: Session = Depends(get_db)
+):
+    try:
+        records = db.query(RecipeDB).offset(skip).limit(limit).all()
+        return [convert_db_recipe(rec) for rec in records]
+    except SQLAlchemyError as exc:
+        logger.exception("DB error: %s", exc)
+        raise HTTPException(status_code=503, detail="Database error")
+
+
+@router.get("/recipes/{recipe_id}", response_model=Recipe)
+def get_recipe(recipe_id: str, db: Session = Depends(get_db)):
+    try:
+        rec = (
+            db.query(RecipeDB)
+            .filter(RecipeDB.recipe_id == recipe_id)
+            .first()
+        )
+        if not rec:
+            raise HTTPException(status_code=404, detail="Recipe not found")
+        return convert_db_recipe(rec)
+    except SQLAlchemyError as exc:
+        logger.exception("DB error: %s", exc)
+        raise HTTPException(status_code=503, detail="Database error")
+
+
+@router.post("/recipes", response_model=Recipe, status_code=201)
+def create_recipe(recipe_in: RecipeCreate, db: Session = Depends(get_db)):
+    try:
+        db_recipe = RecipeDB(
+            recipe_id=str(uuid4()),
+            title=recipe_in.title,
+            description=recipe_in.description,
+            variations=recipe_in.variations,
+            chef_guidance=recipe_in.chef_guidance,
+            ai_conversation_prompts=recipe_in.ai_conversation_prompts,
+            storage_and_reheating=recipe_in.storage_and_reheating.dict(),
+            common_troubleshooting=[t.dict() for t in recipe_in.common_troubleshooting],
+            success_metrics=recipe_in.success_metrics.dict(),
+            prep_time_minutes=recipe_in.prep_time_minutes,
+            cook_time_minutes=recipe_in.cook_time_minutes,
+            servings=recipe_in.servings,
+            tags=recipe_in.tags,
+        )
+        db.add(db_recipe)
+        db.flush()
+
+        for ing in recipe_in.ingredients:
+            db_ing = IngredientDB(
+                id=str(uuid4()),
+                recipe_id=db_recipe.recipe_id,
+                name=ing.name,
+                quantity=ing.quantity,
+                unit=ing.unit,
+                category=ing.category,
+                notes=ing.notes,
+            )
+            db.add(db_ing)
+
+        for inst in recipe_in.instructions:
+            db_inst = InstructionDB(
+                id=str(uuid4()),
+                recipe_id=db_recipe.recipe_id,
+                action=inst.action,
+                details=inst.details,
+                time_minutes=inst.time_minutes,
+                safety_warning=inst.safety_warning,
+                priority=inst.priority,
+                ingredients_used=inst.ingredients_used,
+                utensils_used=inst.utensils_used,
+                troubleshooting=[t.dict() for t in inst.troubleshooting],
+            )
+            db.add(db_inst)
+
+        db.commit()
+        db.refresh(db_recipe)
+        return convert_db_recipe(db_recipe)
+    except SQLAlchemyError as exc:
+        logger.exception("DB error: %s", exc)
+        db.rollback()
+        raise HTTPException(status_code=503, detail="Database error")

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,24 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    host = os.getenv("POSTGRES_HOST", "localhost")
+    port = os.getenv("POSTGRES_PORT", "5432")
+    db = os.getenv("POSTGRES_DB", "chefito_db")
+    user = os.getenv("POSTGRES_USER", "postgres")
+    password = os.getenv("POSTGRES_PASSWORD", "postgres")
+    DATABASE_URL = f"postgresql://{user}:{password}@{host}:{port}/{db}"
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/models/recipe_semantic.py
+++ b/app/models/recipe_semantic.py
@@ -1,0 +1,139 @@
+from typing import List, Optional
+from uuid import uuid4
+from pydantic import BaseModel, Field
+
+from sqlalchemy import (
+    Column,
+    String,
+    Integer,
+    Float,
+    ForeignKey,
+    Text,
+)
+from sqlalchemy.dialects.postgresql import UUID, JSONB, ARRAY
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+class TroubleshootingTip(BaseModel):
+    problem: str
+    solution: str
+    sensory_cue: str
+
+class Ingredient(BaseModel):
+    id: str
+    name: str
+    quantity: float
+    unit: str
+    category: str
+    notes: str
+
+class Instruction(BaseModel):
+    id: str
+    action: str
+    details: str
+    time_minutes: Optional[int] = None
+    safety_warning: Optional[str] = None
+    priority: str
+    ingredients_used: List[str]
+    utensils_used: List[str]
+    troubleshooting: List[TroubleshootingTip]
+
+class StoragePeriod(BaseModel):
+    duration: int
+    instructions: str
+
+class StorageAndReheating(BaseModel):
+    refrigerator_storage: StoragePeriod
+    freezer_storage: StoragePeriod
+    reheating_instructions: str
+
+class SuccessMetrics(BaseModel):
+    visual_cues: str
+    texture_goal: str
+    flavor_profile: str
+    aroma_indicators: str
+
+class Recipe(BaseModel):
+    recipe_id: str
+    title: str
+    description: str
+    ingredients: List[Ingredient]
+    instructions: List[Instruction]
+    variations: List[str]
+    chef_guidance: List[str] = Field(alias='chef_guidance')
+    ai_conversation_prompts: List[str]
+    storage_and_reheating: StorageAndReheating
+    common_troubleshooting: List[TroubleshootingTip]
+    success_metrics: SuccessMetrics
+    prep_time_minutes: Optional[int] = None
+    cook_time_minutes: Optional[int] = None
+    servings: Optional[int] = None
+    tags: List[str]
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+# SQLAlchemy models -------------------------------------------------------
+
+
+class RecipeDB(Base):
+    __tablename__ = "recipes"
+
+    recipe_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    title = Column(String, nullable=False)
+    description = Column(Text, nullable=False)
+    variations = Column(ARRAY(String))
+    chef_guidance = Column(ARRAY(String))
+    ai_conversation_prompts = Column(ARRAY(String))
+    storage_and_reheating = Column(JSONB)
+    common_troubleshooting = Column(JSONB)
+    success_metrics = Column(JSONB)
+    prep_time_minutes = Column(Integer)
+    cook_time_minutes = Column(Integer)
+    servings = Column(Integer)
+    tags = Column(ARRAY(String))
+
+    ingredients = relationship(
+        "IngredientDB", back_populates="recipe", cascade="all, delete-orphan"
+    )
+    instructions = relationship(
+        "InstructionDB", back_populates="recipe", cascade="all, delete-orphan"
+    )
+
+
+class IngredientDB(Base):
+    __tablename__ = "ingredients"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    recipe_id = Column(
+        UUID(as_uuid=True), ForeignKey("recipes.recipe_id", ondelete="CASCADE"), index=True
+    )
+    name = Column(String, nullable=False)
+    quantity = Column(Float, nullable=False)
+    unit = Column(String, nullable=False)
+    category = Column(String)
+    notes = Column(Text)
+
+    recipe = relationship("RecipeDB", back_populates="ingredients")
+
+
+class InstructionDB(Base):
+    __tablename__ = "instructions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    recipe_id = Column(
+        UUID(as_uuid=True), ForeignKey("recipes.recipe_id", ondelete="CASCADE"), index=True
+    )
+    action = Column(String, nullable=False)
+    details = Column(Text, nullable=False)
+    time_minutes = Column(Integer)
+    safety_warning = Column(Text)
+    priority = Column(String)
+    ingredients_used = Column(ARRAY(UUID(as_uuid=True)))
+    utensils_used = Column(ARRAY(String))
+    troubleshooting = Column(JSONB)
+
+    recipe = relationship("RecipeDB", back_populates="instructions")
+

--- a/lib/models/recipe_semantic.dart
+++ b/lib/models/recipe_semantic.dart
@@ -1,0 +1,204 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'recipe_semantic.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class TroubleshootingTip {
+  final String problem;
+  final String solution;
+  @JsonKey(name: 'sensory_cue')
+  final String sensoryCue;
+
+  TroubleshootingTip({
+    required this.problem,
+    required this.solution,
+    required this.sensoryCue,
+  });
+
+  factory TroubleshootingTip.fromJson(Map<String, dynamic> json) =>
+      _$TroubleshootingTipFromJson(json);
+  Map<String, dynamic> toJson() => _$TroubleshootingTipToJson(this);
+}
+
+@JsonSerializable()
+class Ingredient {
+  final String id;
+  final String name;
+  final double quantity;
+  final String unit;
+  final String category;
+  final String notes;
+
+  Ingredient({
+    required this.id,
+    required this.name,
+    required this.quantity,
+    required this.unit,
+    required this.category,
+    required this.notes,
+  });
+
+  factory Ingredient.fromJson(Map<String, dynamic> json) =>
+      _$IngredientFromJson(json);
+  Map<String, dynamic> toJson() => _$IngredientToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Instruction {
+  final String id;
+  final String action;
+  final String details;
+  @JsonKey(name: 'time_minutes')
+  final int? timeMinutes;
+  @JsonKey(name: 'safety_warning')
+  final String? safetyWarning;
+  final String priority;
+  @JsonKey(name: 'ingredients_used')
+  final List<String> ingredientsUsed;
+  @JsonKey(name: 'utensils_used')
+  final List<String> utensilsUsed;
+  final List<TroubleshootingTip> troubleshooting;
+
+  Instruction({
+    required this.id,
+    required this.action,
+    required this.details,
+    this.timeMinutes,
+    this.safetyWarning,
+    required this.priority,
+    required this.ingredientsUsed,
+    required this.utensilsUsed,
+    required this.troubleshooting,
+  });
+
+  factory Instruction.fromJson(Map<String, dynamic> json) =>
+      _$InstructionFromJson(json);
+  Map<String, dynamic> toJson() => _$InstructionToJson(this);
+}
+
+@JsonSerializable()
+class StoragePeriod {
+  final int duration;
+  final String instructions;
+
+  StoragePeriod({required this.duration, required this.instructions});
+
+  factory StoragePeriod.fromJson(Map<String, dynamic> json) =>
+      _$StoragePeriodFromJson(json);
+  Map<String, dynamic> toJson() => _$StoragePeriodToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class StorageAndReheating {
+  @JsonKey(name: 'refrigerator_storage')
+  final StoragePeriod refrigeratorStorage;
+  @JsonKey(name: 'freezer_storage')
+  final StoragePeriod freezerStorage;
+  @JsonKey(name: 'reheating_instructions')
+  final String reheatingInstructions;
+
+  StorageAndReheating({
+    required this.refrigeratorStorage,
+    required this.freezerStorage,
+    required this.reheatingInstructions,
+  });
+
+  factory StorageAndReheating.fromJson(Map<String, dynamic> json) =>
+      _$StorageAndReheatingFromJson(json);
+  Map<String, dynamic> toJson() => _$StorageAndReheatingToJson(this);
+}
+
+@JsonSerializable()
+class SuccessMetrics {
+  @JsonKey(name: 'visual_cues')
+  final String visualCues;
+  @JsonKey(name: 'texture_goal')
+  final String textureGoal;
+  @JsonKey(name: 'flavor_profile')
+  final String flavorProfile;
+  @JsonKey(name: 'aroma_indicators')
+  final String aromaIndicators;
+
+  SuccessMetrics({
+    required this.visualCues,
+    required this.textureGoal,
+    required this.flavorProfile,
+    required this.aromaIndicators,
+  });
+
+  factory SuccessMetrics.fromJson(Map<String, dynamic> json) =>
+      _$SuccessMetricsFromJson(json);
+  Map<String, dynamic> toJson() => _$SuccessMetricsToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Recipe {
+  @JsonKey(name: 'recipe_id')
+  final String recipeId;
+  final String title;
+  final String description;
+  final List<Ingredient> ingredients;
+  final List<Instruction> instructions;
+  final List<String> variations;
+  @JsonKey(name: 'chef_guidance')
+  final List<String> chefGuidance;
+  @JsonKey(name: 'ai_conversation_prompts')
+  final List<String> aiConversationPrompts;
+  @JsonKey(name: 'storage_and_reheating')
+  final StorageAndReheating storageAndReheating;
+  @JsonKey(name: 'common_troubleshooting')
+  final List<TroubleshootingTip> commonTroubleshooting;
+  @JsonKey(name: 'success_metrics')
+  final SuccessMetrics successMetrics;
+  @JsonKey(name: 'prep_time_minutes')
+  final int? prepTimeMinutes;
+  @JsonKey(name: 'cook_time_minutes')
+  final int? cookTimeMinutes;
+  final int? servings;
+  final List<String> tags;
+
+  Recipe({
+    required this.recipeId,
+    required this.title,
+    required this.description,
+    required this.ingredients,
+    required this.instructions,
+    required this.variations,
+    required this.chefGuidance,
+    required this.aiConversationPrompts,
+    required this.storageAndReheating,
+    required this.commonTroubleshooting,
+    required this.successMetrics,
+    this.prepTimeMinutes,
+    this.cookTimeMinutes,
+    this.servings,
+    required this.tags,
+  });
+
+  factory Recipe.fromJson(Map<String, dynamic> json) => _$RecipeFromJson(json);
+  Map<String, dynamic> toJson() => _$RecipeToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class AdaptedRecipeResponse {
+  @JsonKey(name: 'original_recipe_id')
+  final String originalRecipeId;
+  @JsonKey(name: 'constraint_applied')
+  final String constraintApplied;
+  @JsonKey(name: 'suggested_changes_text')
+  final List<String> suggestedChangesText;
+  @JsonKey(name: 'adapted_recipe')
+  final Recipe adaptedRecipe;
+
+  AdaptedRecipeResponse({
+    required this.originalRecipeId,
+    required this.constraintApplied,
+    required this.suggestedChangesText,
+    required this.adaptedRecipe,
+  });
+
+  factory AdaptedRecipeResponse.fromJson(Map<String, dynamic> json) =>
+      _$AdaptedRecipeResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$AdaptedRecipeResponseToJson(this);
+}
+

--- a/lib/models/recipe_semantic.g.dart
+++ b/lib/models/recipe_semantic.g.dart
@@ -1,0 +1,192 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recipe_semantic.dart';
+
+TroubleshootingTip _$TroubleshootingTipFromJson(Map<String, dynamic> json) {
+  return TroubleshootingTip(
+    problem: json['problem'] as String,
+    solution: json['solution'] as String,
+    sensoryCue: json['sensory_cue'] as String,
+  );
+}
+
+Map<String, dynamic> _$TroubleshootingTipToJson(TroubleshootingTip instance) =>
+    <String, dynamic>{
+      'problem': instance.problem,
+      'solution': instance.solution,
+      'sensory_cue': instance.sensoryCue,
+    };
+
+Ingredient _$IngredientFromJson(Map<String, dynamic> json) {
+  return Ingredient(
+    id: json['id'] as String,
+    name: json['name'] as String,
+    quantity: (json['quantity'] as num).toDouble(),
+    unit: json['unit'] as String,
+    category: json['category'] as String,
+    notes: json['notes'] as String,
+  );
+}
+
+Map<String, dynamic> _$IngredientToJson(Ingredient instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'quantity': instance.quantity,
+      'unit': instance.unit,
+      'category': instance.category,
+      'notes': instance.notes,
+    };
+
+Instruction _$InstructionFromJson(Map<String, dynamic> json) {
+  return Instruction(
+    id: json['id'] as String,
+    action: json['action'] as String,
+    details: json['details'] as String,
+    timeMinutes: json['time_minutes'] as int?,
+    safetyWarning: json['safety_warning'] as String?,
+    priority: json['priority'] as String,
+    ingredientsUsed: (json['ingredients_used'] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    utensilsUsed:
+        (json['utensils_used'] as List<dynamic>).map((e) => e as String).toList(),
+    troubleshooting: (json['troubleshooting'] as List<dynamic>)
+        .map((e) => TroubleshootingTip.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}
+
+Map<String, dynamic> _$InstructionToJson(Instruction instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'action': instance.action,
+      'details': instance.details,
+      'time_minutes': instance.timeMinutes,
+      'safety_warning': instance.safetyWarning,
+      'priority': instance.priority,
+      'ingredients_used': instance.ingredientsUsed,
+      'utensils_used': instance.utensilsUsed,
+      'troubleshooting': instance.troubleshooting.map((e) => e.toJson()).toList(),
+    };
+
+StoragePeriod _$StoragePeriodFromJson(Map<String, dynamic> json) {
+  return StoragePeriod(
+    duration: json['duration'] as int,
+    instructions: json['instructions'] as String,
+  );
+}
+
+Map<String, dynamic> _$StoragePeriodToJson(StoragePeriod instance) =>
+    <String, dynamic>{
+      'duration': instance.duration,
+      'instructions': instance.instructions,
+    };
+
+StorageAndReheating _$StorageAndReheatingFromJson(Map<String, dynamic> json) {
+  return StorageAndReheating(
+    refrigeratorStorage: StoragePeriod.fromJson(
+        json['refrigerator_storage'] as Map<String, dynamic>),
+    freezerStorage:
+        StoragePeriod.fromJson(json['freezer_storage'] as Map<String, dynamic>),
+    reheatingInstructions: json['reheating_instructions'] as String,
+  );
+}
+
+Map<String, dynamic> _$StorageAndReheatingToJson(StorageAndReheating instance) =>
+    <String, dynamic>{
+      'refrigerator_storage': instance.refrigeratorStorage.toJson(),
+      'freezer_storage': instance.freezerStorage.toJson(),
+      'reheating_instructions': instance.reheatingInstructions,
+    };
+
+SuccessMetrics _$SuccessMetricsFromJson(Map<String, dynamic> json) {
+  return SuccessMetrics(
+    visualCues: json['visual_cues'] as String,
+    textureGoal: json['texture_goal'] as String,
+    flavorProfile: json['flavor_profile'] as String,
+    aromaIndicators: json['aroma_indicators'] as String,
+  );
+}
+
+Map<String, dynamic> _$SuccessMetricsToJson(SuccessMetrics instance) =>
+    <String, dynamic>{
+      'visual_cues': instance.visualCues,
+      'texture_goal': instance.textureGoal,
+      'flavor_profile': instance.flavorProfile,
+      'aroma_indicators': instance.aromaIndicators,
+    };
+
+Recipe _$RecipeFromJson(Map<String, dynamic> json) {
+  return Recipe(
+    recipeId: json['recipe_id'] as String,
+    title: json['title'] as String,
+    description: json['description'] as String,
+    ingredients: (json['ingredients'] as List<dynamic>)
+        .map((e) => Ingredient.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    instructions: (json['instructions'] as List<dynamic>)
+        .map((e) => Instruction.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    variations:
+        (json['variations'] as List<dynamic>).map((e) => e as String).toList(),
+    chefGuidance: (json['chef_guidance'] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    aiConversationPrompts: (json['ai_conversation_prompts'] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    storageAndReheating: StorageAndReheating.fromJson(
+        json['storage_and_reheating'] as Map<String, dynamic>),
+    commonTroubleshooting: (json['common_troubleshooting'] as List<dynamic>)
+        .map((e) => TroubleshootingTip.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    successMetrics: SuccessMetrics.fromJson(
+        json['success_metrics'] as Map<String, dynamic>),
+    prepTimeMinutes: json['prep_time_minutes'] as int?,
+    cookTimeMinutes: json['cook_time_minutes'] as int?,
+    servings: json['servings'] as int?,
+    tags:
+        (json['tags'] as List<dynamic>).map((e) => e as String).toList(),
+  );
+}
+
+Map<String, dynamic> _$RecipeToJson(Recipe instance) => <String, dynamic>{
+      'recipe_id': instance.recipeId,
+      'title': instance.title,
+      'description': instance.description,
+      'ingredients': instance.ingredients.map((e) => e.toJson()).toList(),
+      'instructions': instance.instructions.map((e) => e.toJson()).toList(),
+      'variations': instance.variations,
+      'chef_guidance': instance.chefGuidance,
+      'ai_conversation_prompts': instance.aiConversationPrompts,
+      'storage_and_reheating': instance.storageAndReheating.toJson(),
+      'common_troubleshooting':
+          instance.commonTroubleshooting.map((e) => e.toJson()).toList(),
+      'success_metrics': instance.successMetrics.toJson(),
+      'prep_time_minutes': instance.prepTimeMinutes,
+      'cook_time_minutes': instance.cookTimeMinutes,
+      'servings': instance.servings,
+      'tags': instance.tags,
+    };
+
+AdaptedRecipeResponse _$AdaptedRecipeResponseFromJson(Map<String, dynamic> json) {
+  return AdaptedRecipeResponse(
+    originalRecipeId: json['original_recipe_id'] as String,
+    constraintApplied: json['constraint_applied'] as String,
+    suggestedChangesText: (json['suggested_changes_text'] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    adaptedRecipe:
+        Recipe.fromJson(json['adapted_recipe'] as Map<String, dynamic>),
+  );
+}
+
+Map<String, dynamic> _$AdaptedRecipeResponseToJson(
+        AdaptedRecipeResponse instance) =>
+    <String, dynamic>{
+      'original_recipe_id': instance.originalRecipeId,
+      'constraint_applied': instance.constraintApplied,
+      'suggested_changes_text': instance.suggestedChangesText,
+      'adapted_recipe': instance.adaptedRecipe.toJson(),
+    };
+

--- a/lib/models/recognition_result.dart
+++ b/lib/models/recognition_result.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'recognition_result.g.dart';
+
+@JsonSerializable()
+class RecognizedItem {
+  final String name;
+  final double confidence;
+  @JsonKey(name: 'visual_description')
+  final String visualDescription;
+  @JsonKey(name: 'tactile_description')
+  final String tactileDescription;
+  @JsonKey(name: 'olfactory_description')
+  final String olfactoryDescription;
+
+  RecognizedItem({
+    required this.name,
+    required this.confidence,
+    required this.visualDescription,
+    required this.tactileDescription,
+    required this.olfactoryDescription,
+  });
+
+  factory RecognizedItem.fromJson(Map<String, dynamic> json) =>
+      _$RecognizedItemFromJson(json);
+  Map<String, dynamic> toJson() => _$RecognizedItemToJson(this);
+}
+
+@JsonSerializable()
+class RecognitionResponse {
+  @JsonKey(name: 'recognized_items')
+  final List<RecognizedItem> recognizedItems;
+
+  RecognitionResponse({required this.recognizedItems});
+
+  factory RecognitionResponse.fromJson(Map<String, dynamic> json) =>
+      _$RecognitionResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$RecognitionResponseToJson(this);
+}

--- a/lib/models/recognition_result.g.dart
+++ b/lib/models/recognition_result.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'recognition_result.dart';
+
+RecognizedItem _$RecognizedItemFromJson(Map<String, dynamic> json) {
+  return RecognizedItem(
+    name: json['name'] as String,
+    confidence: (json['confidence'] as num).toDouble(),
+    visualDescription: json['visual_description'] as String,
+    tactileDescription: json['tactile_description'] as String,
+    olfactoryDescription: json['olfactory_description'] as String,
+  );
+}
+
+Map<String, dynamic> _$RecognizedItemToJson(RecognizedItem instance) => <String, dynamic>{
+      'name': instance.name,
+      'confidence': instance.confidence,
+      'visual_description': instance.visualDescription,
+      'tactile_description': instance.tactileDescription,
+      'olfactory_description': instance.olfactoryDescription,
+    };
+
+RecognitionResponse _$RecognitionResponseFromJson(Map<String, dynamic> json) {
+  return RecognitionResponse(
+    recognizedItems: (json['recognized_items'] as List<dynamic>)
+        .map((e) => RecognizedItem.fromJson(e as Map<String, dynamic>))
+        .toList(),
+  );
+}
+
+Map<String, dynamic> _$RecognitionResponseToJson(RecognitionResponse instance) => <String, dynamic>{
+      'recognized_items': instance.recognizedItems.map((e) => e.toJson()).toList(),
+    };

--- a/lib/screens/ingredient_recognition_screen.dart
+++ b/lib/screens/ingredient_recognition_screen.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+import '../services/recipe_api_service_semantic.dart';
+import '../models/recognition_result.dart';
+
+class IngredientRecognitionScreen extends StatefulWidget {
+  final RecipeApiServiceSemantic apiService;
+  final FlutterTts tts;
+  final ImagePicker picker;
+  const IngredientRecognitionScreen({Key? key, required this.apiService, FlutterTts? tts, ImagePicker? picker})
+      : tts = tts ?? const FlutterTts(),
+        picker = picker ?? const ImagePicker(),
+        super(key: key);
+
+  @override
+  State<IngredientRecognitionScreen> createState() => _IngredientRecognitionScreenState();
+}
+
+class _IngredientRecognitionScreenState extends State<IngredientRecognitionScreen> {
+  RecognitionResponse? _result;
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _pick() async {
+    final XFile? file = await widget.picker.pickImage(source: ImageSource.camera);
+    if (file == null) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final resp = await widget.apiService.recognizeIngredients(File(file.path));
+      await widget.tts.speak(resp.recognizedItems.map((e) => e.name).join(', '));
+      setState(() => _result = resp);
+    } on ApiException catch (e) {
+      setState(() => _error = e.message);
+    } on NetworkException catch (_) {
+      setState(() => _error = 'Problème réseau');
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reconnaissance d\'ingrédients')),
+      body: Center(
+        child: _loading
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: const [CircularProgressIndicator(), Text('Analyse en cours...')],
+              )
+            : _error != null
+                ? Text(_error!)
+                : _result == null
+                    ? const Text('Prenez une photo pour commencer')
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: _result!.recognizedItems
+                            .map((e) => Text('${e.name} - ${(e.confidence * 100).toStringAsFixed(0)}%'))
+                            .toList(),
+                      ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _pick,
+        child: const Icon(Icons.camera_alt),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/recipe_detail_screen_semantic.dart
+++ b/lib/screens/recipe_detail_screen_semantic.dart
@@ -1,0 +1,393 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:vibration/vibration.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+
+import '../services/recipe_api_service_semantic.dart';
+import '../models/recipe_semantic.dart';
+import 'ingredient_recognition_screen.dart';
+
+typedef VibrateCallback = Future<void> Function(int duration);
+
+class RecipeDetailScreenSemantic extends StatefulWidget {
+  final RecipeApiServiceSemantic apiService;
+  final String recipeId;
+  final FlutterTts tts;
+  final AudioPlayer audioPlayer;
+  final VibrateCallback vibrate;
+  final stt.SpeechToText speech;
+
+  RecipeDetailScreenSemantic({
+    Key? key,
+    required this.apiService,
+    required this.recipeId,
+    FlutterTts? tts,
+    AudioPlayer? audioPlayer,
+    VibrateCallback? vibrate,
+    stt.SpeechToText? speech,
+  })  : tts = tts ?? FlutterTts(),
+        audioPlayer = audioPlayer ?? AudioPlayer(),
+        vibrate = vibrate ?? ((d) => Vibration.vibrate(duration: d)),
+        speech = speech ?? stt.SpeechToText(),
+        super(key: key);
+
+  @override
+  State<RecipeDetailScreenSemantic> createState() => _RecipeDetailScreenSemanticState();
+}
+
+class _RecipeDetailScreenSemanticState extends State<RecipeDetailScreenSemantic> {
+  Recipe? _recipe;
+  bool _loading = true;
+  String? _error;
+  int _index = 0;
+  late final PageController _pageController;
+  late final stt.SpeechToText _speech;
+  bool _speechAvailable = false;
+  bool _adapting = false;
+  bool _awaitingConfirm = false;
+  AdaptedRecipeResponse? _pendingAdapt;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+    _speech = widget.speech;
+    _initSpeech();
+    _load();
+  }
+
+  Future<void> _initSpeech() async {
+    _speechAvailable = await _speech.initialize();
+    if (_speechAvailable && _speech.hasPermission) {
+      await _speech.listen(onResult: _onSpeechResult);
+    } else {
+      setState(() => _speechAvailable = false);
+    }
+  }
+
+  Future<void> _load() async {
+    try {
+      _recipe = await widget.apiService.fetchRecipe(widget.recipeId);
+    } on NetworkException catch (_) {
+      _error = 'Problème de connexion';
+    } on ApiException catch (e) {
+      _error = e.message;
+    } finally {
+      setState(() {
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _speakCurrent() async {
+    await widget.audioPlayer.setAsset('assets/sounds/double_tap.mp3');
+    await widget.audioPlayer.play();
+    await widget.vibrate(50);
+    await widget.tts.speak(_recipe!.instructions[_index].details);
+  }
+
+  Future<void> _onPageChanged(int i) async {
+    setState(() => _index = i);
+    await widget.vibrate(30);
+  }
+
+  void _openMenu() {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ListTile(
+            title: const Text('Liste Ingrédients'),
+            onTap: () {
+              Navigator.pop(context);
+              // placeholder
+            },
+          ),
+          ListTile(
+            title: const Text('Conseils'),
+            onTap: () {
+              Navigator.pop(context);
+            },
+          ),
+          ListTile(
+            title: const Text('Dépannage'),
+            onTap: () {
+              Navigator.pop(context);
+            },
+          ),
+          ListTile(
+            title: const Text('Reconnaître ingrédients'),
+            onTap: () {
+              Navigator.pop(context);
+              _openRecognition();
+            },
+          ),
+          ListTile(
+            title: const Text('Répéter'),
+            onTap: () {
+              Navigator.pop(context);
+              _speakCurrent();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openRecognition() {
+    Navigator.of(context).push(MaterialPageRoute(
+        builder: (_) => IngredientRecognitionScreen(
+              apiService: widget.apiService,
+            )));
+  }
+
+  void _onSpeechResult(stt.SpeechRecognitionResult result) {
+    if (result.finalResult) {
+      widget.audioPlayer.setAsset('assets/sounds/command.mp3');
+      widget.audioPlayer.play();
+      widget.vibrate(30);
+      _handleCommand(result.recognizedWords.toLowerCase());
+      if (_speechAvailable && !_speech.isListening) {
+        _speech.listen(onResult: _onSpeechResult);
+      }
+    }
+  }
+
+  void _handleCommand(String command) {
+    final recipe = _recipe;
+    if (recipe == null) return;
+    if (_awaitingConfirm) {
+      if (command.contains('oui')) {
+        setState(() {
+          _recipe = _pendingAdapt!.adaptedRecipe;
+          _index = 0;
+        });
+        _speak('Adaptation appliquée');
+      } else if (command.contains('non')) {
+        _speak('Adaptation annulée');
+      } else {
+        _speak('Veuillez répondre oui ou non');
+        return;
+      }
+      _awaitingConfirm = false;
+      _pendingAdapt = null;
+      return;
+    }
+    if (command.contains('étape suivante')) {
+      _nextStep();
+    } else if (command.contains('étape précédente')) {
+      _prevStep();
+    } else if (command.contains('répète')) {
+      _speakCurrent();
+    } else if (command.contains('va') && RegExp(r'étape\s*(\d+)').hasMatch(command)) {
+      final m = RegExp(r'étape\s*(\d+)').firstMatch(command);
+      if (m != null) _gotoStep(int.parse(m.group(1)!));
+    } else if (command.contains("où en suis-je")) {
+      _speak('Vous êtes à l\'étape ${_index + 1} sur ${recipe.instructions.length}');
+    } else if (command.contains("combien d'étapes restent")) {
+      final remain = recipe.instructions.length - _index - 1;
+      _speak('Il reste $remain étapes');
+    } else if (command.contains('liste des ingrédients')) {
+      final names = recipe.ingredients.map((e) => e.name).join(', ');
+      _speak(names);
+    } else if (command.startsWith('quantité de')) {
+      final name = command.replaceFirst('quantité de', '').trim();
+      final ing = recipe.ingredients.firstWhere(
+        (i) => i.name.toLowerCase() == name,
+        orElse: () => Ingredient(
+            id: '', name: '', quantity: 0, unit: '', category: '', notes: ''),
+      );
+      if (ing.id.isNotEmpty) {
+        _speak('${ing.quantity} ${ing.unit} de ${ing.name}');
+      } else {
+        _speak('Ingrédient non trouvé');
+      }
+    } else if (RegExp(r'ingr[éè]dient.*étape\s*(\d+)').hasMatch(command)) {
+      final m = RegExp(r'ingr[éè]dient.*étape\s*(\d+)').firstMatch(command);
+      if (m != null) {
+        final idx = int.parse(m.group(1)!);
+        if (idx >= 1 && idx <= recipe.instructions.length) {
+          final ids = recipe.instructions[idx - 1].ingredientsUsed;
+          final names = recipe.ingredients
+              .where((i) => ids.contains(i.id))
+              .map((e) => e.name)
+              .join(', ');
+          _speak(names.isEmpty ? 'Aucun ingrédient pour cette étape' : names);
+        }
+      }
+    } else if (command.contains('temps de cuisson total')) {
+      if (recipe.cookTimeMinutes != null) {
+        _speak('${recipe.cookTimeMinutes} minutes');
+      }
+    } else if (command.contains('combien de temps pour cette étape')) {
+      final t = recipe.instructions[_index].timeMinutes;
+      _speak(t != null ? '$t minutes' : 'Pas de temps indiqué');
+    } else if (command.startsWith('conseil pour')) {
+      final q = command.replaceFirst('conseil pour', '').trim();
+      final tip = recipe.chefGuidance.firstWhere(
+        (g) => g.toLowerCase().contains(q),
+        orElse: () => recipe.chefGuidance.isNotEmpty ? recipe.chefGuidance.first : '',
+      );
+      if (tip.isNotEmpty) _speak(tip);
+    } else if (command.startsWith('que faire si')) {
+      final q = command.replaceFirst('que faire si', '').trim();
+      final t = recipe.commonTroubleshooting.firstWhere(
+          (t) => t.problem.toLowerCase().contains(q),
+          orElse: () => recipe.commonTroubleshooting.isNotEmpty
+              ? recipe.commonTroubleshooting.first
+              : TroubleshootingTip(problem: '', solution: '', sensoryCue: ''));
+      if (t.solution.isNotEmpty) _speak(t.solution);
+    } else if (command.contains("pas d'oeuf") ||
+        command.contains("pas d'œuf") ||
+        command.contains('sans oeuf') ||
+        command.contains('je n\'ai pas d\'oeufs')) {
+      _requestAdaptation("pas d'oeufs");
+    } else if (command.contains('pas de four') || command.contains('sans four')) {
+      _requestAdaptation('pas de four');
+    } else if (command.contains('sans lactose') ||
+        command.contains('allergique au lactose')) {
+      _requestAdaptation('sans lactose');
+    } else if (command.contains('vérifie mes ingrédients') ||
+        command.contains('verifie mes ingredients')) {
+      _openRecognition();
+    }
+  }
+
+  Future<void> _speak(String text) async {
+    await widget.tts.speak(text);
+  }
+
+  void _nextStep() {
+    if (_index < _recipe!.instructions.length - 1) {
+      _pageController.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+    }
+  }
+
+  void _prevStep() {
+    if (_index > 0) {
+      _pageController.previousPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+    }
+  }
+
+  void _gotoStep(int step) {
+    if (step >= 1 && step <= _recipe!.instructions.length) {
+      _pageController.jumpToPage(step - 1);
+    }
+  }
+
+  Future<void> _requestAdaptation(String constraint) async {
+    setState(() => _adapting = true);
+    await _speak("D'accord, je cherche une adaptation...");
+    try {
+      final resp =
+          await widget.apiService.adaptRecipe(widget.recipeId, constraint);
+      await widget.audioPlayer.setAsset('assets/sounds/command.mp3');
+      await widget.audioPlayer.play();
+      await widget.vibrate(40);
+      await _speak(resp.suggestedChangesText.join('. '));
+      await _speak('Voulez-vous appliquer cette adaptation ?');
+      _pendingAdapt = resp;
+      _awaitingConfirm = true;
+    } on NetworkException catch (_) {
+      await _speak('Problème de connexion');
+    } on ApiException catch (e) {
+      await _speak('Erreur: ${e.message}');
+    } finally {
+      setState(() => _adapting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_error != null) {
+      return Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(_error!),
+              const SizedBox(height: 8),
+              ElevatedButton(onPressed: _load, child: const Text('Réessayer')),
+            ],
+          ),
+        ),
+      );
+    }
+    final recipe = _recipe!;
+    return Scaffold(
+      appBar: AppBar(title: Text(recipe.title)),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _openMenu,
+        child: const Icon(Icons.menu),
+      ),
+      body: Stack(
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('Ingrédients:', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                    ...recipe.ingredients.map((i) => Text(i.name, style: const TextStyle(fontSize: 18))),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: PageView.builder(
+                  controller: _pageController,
+                  onPageChanged: _onPageChanged,
+                  itemCount: recipe.instructions.length,
+                  itemBuilder: (context, index) {
+                    final instr = recipe.instructions[index];
+                    return GestureDetector(
+                      onDoubleTap: _speakCurrent,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Étape ${index + 1} sur ${recipe.instructions.length}', style: const TextStyle(fontSize: 18)),
+                            const SizedBox(height: 16),
+                            Text(instr.action, style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+                            const SizedBox(height: 8),
+                            Expanded(
+                              child: SingleChildScrollView(
+                                child: Text(instr.details, style: const TextStyle(fontSize: 18)),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+          Positioned(
+            top: 8,
+            right: 8,
+            child: Icon(
+              _speech.isListening ? Icons.mic : Icons.mic_off,
+              color: Colors.red,
+            ),
+          ),
+          if (_adapting)
+            const Center(
+              child: CircularProgressIndicator(),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/recipe_list_screen_semantic.dart
+++ b/lib/screens/recipe_list_screen_semantic.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/recipe_semantic.dart';
+import '../services/recipe_api_service_semantic.dart';
+
+class RecipeListNotifier extends ChangeNotifier {
+  final RecipeApiServiceSemantic api;
+  List<Recipe> recipes = [];
+  bool loading = false;
+  String? error;
+
+  RecipeListNotifier({required this.api});
+
+  Future<void> loadRecipes() async {
+    loading = true;
+    error = null;
+    notifyListeners();
+    try {
+      recipes = await api.fetchRecipes();
+    } on NetworkException catch (_) {
+      error = 'Connexion réseau impossible';
+    } on ApiException catch (e) {
+      error = e.message;
+    } catch (_) {
+      error = 'Erreur inconnue';
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+}
+
+class RecipeListScreenSemantic extends StatefulWidget {
+  final RecipeApiServiceSemantic apiService;
+  const RecipeListScreenSemantic({Key? key, required this.apiService}) : super(key: key);
+
+  @override
+  State<RecipeListScreenSemantic> createState() => _RecipeListScreenSemanticState();
+}
+
+class _RecipeListScreenSemanticState extends State<RecipeListScreenSemantic> {
+  late final RecipeListNotifier notifier;
+
+  @override
+  void initState() {
+    super.initState();
+    notifier = RecipeListNotifier(api: widget.apiService);
+    notifier.loadRecipes();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<RecipeListNotifier>.value(
+      value: notifier,
+      child: Consumer<RecipeListNotifier>(
+        builder: (context, state, _) {
+          if (state.loading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (state.error != null) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(state.error!),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: state.loadRecipes,
+                    child: const Text('Réessayer'),
+                  ),
+                ],
+              ),
+            );
+          }
+          return ListView.builder(
+            itemCount: state.recipes.length,
+            itemBuilder: (context, index) {
+              final recipe = state.recipes[index];
+              return Card(
+                child: ListTile(
+                  title: Text(recipe.title),
+                  subtitle: Text(recipe.description),
+                  onTap: () {
+                    Navigator.of(context).pushNamed('/recipe/${recipe.recipeId}');
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/services/recipe_api_service_semantic.dart
+++ b/lib/services/recipe_api_service_semantic.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:http/http.dart' as http;
+
+import '../models/recipe_semantic.dart';
+import '../models/recognition_result.dart';
+
+class ApiException implements Exception {
+  final String message;
+  ApiException(this.message);
+
+  @override
+  String toString() => 'ApiException: $message';
+}
+
+class NetworkException implements Exception {
+  final String message;
+  NetworkException(this.message);
+
+  @override
+  String toString() => 'NetworkException: $message';
+}
+
+class RecipeApiServiceSemantic {
+  final String baseUrl;
+  final http.Client client;
+
+  RecipeApiServiceSemantic({required this.baseUrl, http.Client? client})
+      : client = client ?? http.Client();
+
+  Future<List<Recipe>> fetchRecipes() async {
+    try {
+      final response = await client.get(Uri.parse('$baseUrl/recipes'));
+      if (response.statusCode == 200) {
+        final List<dynamic> data = json.decode(response.body);
+        return data
+            .map((e) => Recipe.fromJson(e as Map<String, dynamic>))
+            .toList();
+      } else if (response.statusCode >= 500) {
+        throw ApiException('Server error (${response.statusCode})');
+      } else {
+        throw ApiException('Request failed (${response.statusCode})');
+      }
+    } on http.ClientException catch (e) {
+      throw NetworkException(e.message);
+    }
+  }
+
+  Future<Recipe> fetchRecipe(String id) async {
+    try {
+      final response = await client.get(Uri.parse('$baseUrl/recipes/$id'));
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        return Recipe.fromJson(data);
+      } else if (response.statusCode == 404) {
+        throw ApiException('Recipe not found');
+      } else if (response.statusCode >= 500) {
+        throw ApiException('Server error (${response.statusCode})');
+      } else {
+        throw ApiException('Request failed (${response.statusCode})');
+      }
+    } on http.ClientException catch (e) {
+      throw NetworkException(e.message);
+    }
+  }
+
+  Future<AdaptedRecipeResponse> adaptRecipe(
+      String id, String constraint) async {
+    try {
+      final response = await client.post(
+        Uri.parse('$baseUrl/recipes/$id/adapt'),
+        headers: {'Content-Type': 'application/json'},
+        body: json.encode({'constraint': constraint}),
+      );
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        return AdaptedRecipeResponse.fromJson(data);
+      } else if (response.statusCode == 400) {
+        throw ApiException('Constraint not supported');
+      } else if (response.statusCode >= 500) {
+        throw ApiException('Server error (${response.statusCode})');
+      } else {
+        throw ApiException('Request failed (${response.statusCode})');
+      }
+    } on http.ClientException catch (e) {
+      throw NetworkException(e.message);
+    }
+  }
+
+  Future<RecognitionResponse> recognizeIngredients(File imageFile) async {
+    final uri = Uri.parse('$baseUrl/ingredients/recognize');
+    final request = http.MultipartRequest('POST', uri)
+      ..files.add(await http.MultipartFile.fromPath('file', imageFile.path));
+    http.StreamedResponse streamed;
+    try {
+      streamed = await request.send();
+    } on http.ClientException catch (e) {
+      throw NetworkException(e.message);
+    }
+    final response = await http.Response.fromStream(streamed);
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body) as Map<String, dynamic>;
+      return RecognitionResponse.fromJson(data);
+    } else if (response.statusCode >= 500) {
+      throw ApiException('Server error (${response.statusCode})');
+    } else {
+      throw ApiException('Request failed (${response.statusCode})');
+    }
+  }
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn
+pydantic
+pillow
+numpy
+sqlalchemy
+alembic
+pytest
+httpx

--- a/scripts_content.md
+++ b/scripts_content.md
@@ -1,0 +1,20 @@
+# Example script contents
+
+## setup_vps_security.sh
+```bash
+#!/bin/bash
+# Basic VPS security setup for Chefito
+set -e
+USER="chefito-user"
+adduser --disabled-password --gecos "" "$USER"
+# Additional firewall and package setup commands here
+```
+
+## run_recipe_pipeline.sh
+```bash
+#!/bin/bash
+# Automate recipe ingestion and deployment
+set -e
+# Define variables: PROJECT_ID, BUCKET_NAME, SPOONACULAR_API_KEY, IONOS_IP
+# Fetch recipes and upload to PostgreSQL
+```

--- a/test/models/recipe_semantic_test.dart
+++ b/test/models/recipe_semantic_test.dart
@@ -1,0 +1,79 @@
+import 'package:test/test.dart';
+import 'package:chefito/models/recipe_semantic.dart';
+
+void main() {
+  group('Recipe serialization', () {
+    final Map<String, dynamic> recipeJson = {
+      'recipe_id': '123e4567-e89b-12d3-a456-426614174000',
+      'title': 'Test Recipe',
+      'description': 'A simple test recipe',
+      'ingredients': [
+        {
+          'id': '1',
+          'name': 'Flour',
+          'quantity': 2.0,
+          'unit': 'cups',
+          'category': 'Grain',
+          'notes': 'Use all-purpose flour'
+        }
+      ],
+      'instructions': [
+        {
+          'id': 'step1',
+          'action': 'Mix',
+          'details': 'Mix all ingredients',
+          'time_minutes': 5,
+          'safety_warning': null,
+          'priority': 'high',
+          'ingredients_used': ['1'],
+          'utensils_used': ['bowl'],
+          'troubleshooting': [
+            {
+              'problem': 'Too dry',
+              'solution': 'Add water',
+              'sensory_cue': 'crumbly'
+            }
+          ]
+        }
+      ],
+      'variations': ['Add vanilla'],
+      'chef_guidance': ['Be gentle'],
+      'ai_conversation_prompts': ['How do I mix?'],
+      'storage_and_reheating': {
+        'refrigerator_storage': {
+          'duration': 3,
+          'instructions': 'Store covered'
+        },
+        'freezer_storage': {
+          'duration': 1,
+          'instructions': 'Freeze tightly'
+        },
+        'reheating_instructions': 'Microwave for 1 min'
+      },
+      'common_troubleshooting': [
+        {
+          'problem': 'Burnt',
+          'solution': 'Lower heat',
+          'sensory_cue': 'smell'
+        }
+      ],
+      'success_metrics': {
+        'visual_cues': 'Golden brown',
+        'texture_goal': 'Soft',
+        'flavor_profile': 'Sweet',
+        'aroma_indicators': 'Pleasant'
+      },
+      'prep_time_minutes': 10,
+      'cook_time_minutes': 20,
+      'servings': 4,
+      'tags': ['dessert']
+    };
+
+    test('fromJson and toJson', () {
+      final recipe = Recipe.fromJson(recipeJson);
+      expect(recipe.title, equals('Test Recipe'));
+      final roundtrip = recipe.toJson();
+      expect(roundtrip, equals(recipeJson));
+    });
+  });
+}

--- a/test/screens/ingredient_recognition_screen_test.dart
+++ b/test/screens/ingredient_recognition_screen_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+import 'package:chefito/screens/ingredient_recognition_screen.dart';
+import 'package:chefito/services/recipe_api_service_semantic.dart';
+import 'package:chefito/models/recognition_result.dart';
+
+class MockService extends Mock implements RecipeApiServiceSemantic {}
+class MockPicker extends Mock implements ImagePicker {}
+class MockTts extends Mock implements FlutterTts {}
+
+void main() {
+  testWidgets('shows results after recognition', (tester) async {
+    final service = MockService();
+    final picker = MockPicker();
+    final tts = MockTts();
+    when(picker.pickImage(source: ImageSource.camera)).thenAnswer((_) async =>
+        XFile('test.png'));
+    when(service.recognizeIngredients(any)).thenAnswer((_) async =>
+        RecognitionResponse(recognizedItems: [
+          RecognizedItem(
+              name: 'tomate',
+              confidence: 0.8,
+              visualDescription: 'rouge',
+              tactileDescription: 'lisse',
+              olfactoryDescription: 'sucree')
+        ]));
+    await tester.pumpWidget(MaterialApp(
+      home: IngredientRecognitionScreen(
+        apiService: service,
+        tts: tts,
+        picker: picker,
+      ),
+    ));
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    verify(tts.speak('tomate')).called(1);
+    await tester.pump();
+    expect(find.textContaining('tomate'), findsOneWidget);
+  });
+
+  testWidgets('shows error on failure', (tester) async {
+    final service = MockService();
+    final picker = MockPicker();
+    when(picker.pickImage(source: ImageSource.camera)).thenAnswer((_) async =>
+        XFile('test.png'));
+    when(service.recognizeIngredients(any)).thenThrow(ApiException('fail'));
+    await tester.pumpWidget(MaterialApp(
+      home: IngredientRecognitionScreen(apiService: service, picker: picker),
+    ));
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    await tester.pump();
+    expect(find.textContaining('fail'), findsOneWidget);
+  });
+}

--- a/test/screens/recipe_detail_screen_semantic_test.dart
+++ b/test/screens/recipe_detail_screen_semantic_test.dart
@@ -1,0 +1,437 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+
+import 'package:chefito/screens/recipe_detail_screen_semantic.dart';
+import 'package:chefito/services/recipe_api_service_semantic.dart';
+import 'package:chefito/models/recipe_semantic.dart';
+import 'package:chefito/services/recipe_api_service_semantic.dart' show ApiException;
+
+class MockService extends Mock implements RecipeApiServiceSemantic {}
+class MockTts extends Mock implements FlutterTts {}
+class MockAudio extends Mock implements AudioPlayer {}
+class MockSpeech extends Mock implements stt.SpeechToText {}
+
+Recipe sampleRecipe() => Recipe(
+      recipeId: '1',
+      title: 'R',
+      description: 'D',
+      ingredients: [
+        Ingredient(id: 'i1', name: 'ing', quantity: 1, unit: 'u', category: 'c', notes: '')
+      ],
+      instructions: [
+        Instruction(
+          id: 's1',
+          action: 'A1',
+          details: 'D1',
+          timeMinutes: null,
+          safetyWarning: null,
+          priority: 'high',
+          ingredientsUsed: [],
+          utensilsUsed: [],
+          troubleshooting: [],
+        ),
+        Instruction(
+          id: 's2',
+          action: 'A2',
+          details: 'D2',
+          timeMinutes: null,
+          safetyWarning: null,
+          priority: 'high',
+          ingredientsUsed: [],
+          utensilsUsed: [],
+          troubleshooting: [],
+        ),
+      ],
+      variations: [],
+      chefGuidance: ['utilise un fouet'],
+      aiConversationPrompts: [],
+      storageAndReheating: StorageAndReheating(
+        refrigeratorStorage: StoragePeriod(duration: 1, instructions: ''),
+        freezerStorage: StoragePeriod(duration: 1, instructions: ''),
+        reheatingInstructions: '',
+      ),
+      commonTroubleshooting: [
+        TroubleshootingTip(problem: 'pate colle', solution: 'ajouter farine', sensoryCue: '')
+      ],
+      successMetrics: SuccessMetrics(
+          visualCues: '', textureGoal: '', flavorProfile: '', aromaIndicators: ''),
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      servings: null,
+    tags: [],
+  );
+
+Recipe adaptedRecipe() => Recipe(
+      recipeId: '1',
+      title: 'R2',
+      description: 'D',
+      ingredients: [
+        Ingredient(id: 'i1', name: 'ing', quantity: 1, unit: 'u', category: 'c', notes: '')
+      ],
+      instructions: [
+        Instruction(
+          id: 's1',
+          action: 'A1',
+          details: 'D1',
+          timeMinutes: null,
+          safetyWarning: null,
+          priority: 'high',
+          ingredientsUsed: [],
+          utensilsUsed: [],
+          troubleshooting: [],
+        ),
+        Instruction(
+          id: 's2',
+          action: 'A2',
+          details: 'D2',
+          timeMinutes: null,
+          safetyWarning: null,
+          priority: 'high',
+          ingredientsUsed: [],
+          utensilsUsed: [],
+          troubleshooting: [],
+        ),
+      ],
+      variations: [],
+      chefGuidance: ['utilise un fouet'],
+      aiConversationPrompts: [],
+      storageAndReheating: StorageAndReheating(
+        refrigeratorStorage: StoragePeriod(duration: 1, instructions: ''),
+        freezerStorage: StoragePeriod(duration: 1, instructions: ''),
+        reheatingInstructions: '',
+      ),
+      commonTroubleshooting: [
+        TroubleshootingTip(problem: 'pate colle', solution: 'ajouter farine', sensoryCue: '')
+      ],
+      successMetrics: SuccessMetrics(
+          visualCues: '', textureGoal: '', flavorProfile: '', aromaIndicators: ''),
+      prepTimeMinutes: null,
+      cookTimeMinutes: null,
+      servings: null,
+      tags: [],
+    );
+
+void main() {
+  testWidgets('shows loading indicator', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(apiService: service, recipeId: '1'),
+    ));
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('shows recipe when loaded', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(apiService: service, recipeId: '1'),
+    ));
+    await tester.pump();
+    expect(find.text('R'), findsOneWidget);
+    expect(find.textContaining('Étape 1'), findsOneWidget);
+  });
+
+  testWidgets('swipe navigates between instructions and vibrates', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    bool vibrated = false;
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        vibrate: (d) async {
+          vibrated = true;
+        },
+      ),
+    ));
+    await tester.pump();
+    expect(find.text('A1'), findsOneWidget);
+    await tester.drag(find.byType(PageView), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+    expect(find.text('A2'), findsOneWidget);
+    expect(vibrated, isTrue);
+  });
+
+  testWidgets('double tap speaks instruction', (tester) async {
+    final service = MockService();
+    final tts = MockTts();
+    final audio = MockAudio();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        tts: tts,
+        audioPlayer: audio,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    final gesture = await tester.startGesture(tester.getCenter(find.byType(GestureDetector)));
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 50));
+    await gesture.down(tester.getCenter(find.byType(GestureDetector)));
+    await gesture.up();
+    await tester.pump();
+    verify(tts.speak('D1')).called(1);
+    verify(audio.play()).called(1);
+  });
+
+  testWidgets('shows error message on failure', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipe('1')).thenThrow(ApiException('fail'));
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(apiService: service, recipeId: '1'),
+    ));
+    await tester.pump();
+    await tester.pump();
+    expect(find.textContaining('fail'), findsOneWidget);
+  });
+
+  testWidgets('floating button opens menu', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(apiService: service, recipeId: '1'),
+    ));
+    await tester.pump();
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(find.text('Liste Ingrédients'), findsOneWidget);
+    expect(find.text('Reconnaître ingrédients'), findsOneWidget);
+  });
+
+  testWidgets('speech service initializes', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(speech.initialize()).thenAnswer((_) async => true);
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((_) async => true);
+    when(speech.hasPermission).thenReturn(true);
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+      ),
+    ));
+    await tester.pump();
+    verify(speech.initialize()).called(1);
+    verify(speech.listen(onResult: anyNamed('onResult'))).called(1);
+  });
+
+  testWidgets('voice command next step', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(speech.initialize()).thenAnswer((_) async => true);
+    late void Function(stt.SpeechRecognitionResult) onResult;
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((invocation) async {
+      onResult = invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+      return true;
+    });
+    when(speech.hasPermission).thenReturn(true);
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    expect(find.text('A1'), findsOneWidget);
+    onResult(stt.SpeechRecognitionResult('étape suivante', true));
+    await tester.pumpAndSettle();
+    expect(find.text('A2'), findsOneWidget);
+  });
+
+  testWidgets('voice command ingredient quantity', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    final tts = MockTts();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(speech.initialize()).thenAnswer((_) async => true);
+    late void Function(stt.SpeechRecognitionResult) onResult;
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((invocation) async {
+      onResult = invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+      return true;
+    });
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+        tts: tts,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    onResult(stt.SpeechRecognitionResult('quantité de ing', true));
+    await tester.pump();
+    verify(tts.speak('1 u de ing')).called(1);
+  });
+
+  testWidgets('voice command goto step', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(speech.initialize()).thenAnswer((_) async => true);
+    late void Function(stt.SpeechRecognitionResult) onResult;
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((invocation) async {
+      onResult = invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+      return true;
+    });
+    when(speech.hasPermission).thenReturn(true);
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    onResult(stt.SpeechRecognitionResult("va à l'étape 2", true));
+    await tester.pumpAndSettle();
+    expect(find.text('A2'), findsOneWidget);
+  });
+
+  testWidgets('voice command troubleshooting tip', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    final tts = MockTts();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(speech.initialize()).thenAnswer((_) async => true);
+    late void Function(stt.SpeechRecognitionResult) onResult;
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((invocation) async {
+      onResult = invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+      return true;
+    });
+    when(speech.hasPermission).thenReturn(true);
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+        tts: tts,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    onResult(stt.SpeechRecognitionResult('que faire si pate colle', true));
+    await tester.pump();
+    verify(tts.speak('ajouter farine')).called(1);
+  });
+
+  testWidgets('voice command adaptation success', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    final tts = MockTts();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(service.adaptRecipe('1', 'sans lactose')).thenAnswer((_) async =>
+        AdaptedRecipeResponse(
+            originalRecipeId: '1',
+            constraintApplied: 'sans lactose',
+            suggestedChangesText: ['remplacer le lait'],
+            adaptedRecipe: adaptedRecipe()));
+    when(speech.initialize()).thenAnswer((_) async => true);
+    late void Function(stt.SpeechRecognitionResult) onResult;
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((invocation)
+        async {
+      onResult =
+          invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+      return true;
+    });
+    when(speech.hasPermission).thenReturn(true);
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+        tts: tts,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    onResult(stt.SpeechRecognitionResult('sans lactose', true));
+    await tester.pump();
+    verify(service.adaptRecipe('1', 'sans lactose')).called(1);
+    verify(tts.speak(contains('remplacer le lait'))).called(1);
+    onResult(stt.SpeechRecognitionResult('oui', true));
+    await tester.pump();
+    expect(find.text('R2'), findsOneWidget);
+  });
+
+  testWidgets('voice command adaptation failure', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    final tts = MockTts();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(service.adaptRecipe('1', 'pas de four'))
+        .thenThrow(ApiException('fail'));
+    when(speech.initialize()).thenAnswer((_) async => true);
+    late void Function(stt.SpeechRecognitionResult) onResult;
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((invocation)
+        async {
+      onResult =
+          invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+      return true;
+    });
+    when(speech.hasPermission).thenReturn(true);
+    await tester.pumpWidget(MaterialApp(
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+        tts: tts,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    onResult(stt.SpeechRecognitionResult('pas de four', true));
+    await tester.pump();
+    verify(tts.speak(contains('Erreur'))).called(1);
+  });
+
+  testWidgets('voice command opens recognition', (tester) async {
+    final service = MockService();
+    final speech = MockSpeech();
+    when(service.fetchRecipe('1')).thenAnswer((_) async => sampleRecipe());
+    when(speech.initialize()).thenAnswer((_) async => true);
+    late void Function(stt.SpeechRecognitionResult) onResult;
+    when(speech.listen(onResult: anyNamed('onResult'))).thenAnswer((invocation) async {
+      onResult = invocation.namedArguments[#onResult] as void Function(stt.SpeechRecognitionResult);
+      return true;
+    });
+    when(speech.hasPermission).thenReturn(true);
+    final observer = TestNavigatorObserver();
+    await tester.pumpWidget(MaterialApp(
+      navigatorObservers: [observer],
+      home: RecipeDetailScreenSemantic(
+        apiService: service,
+        recipeId: '1',
+        speech: speech,
+        vibrate: (_) async {},
+      ),
+    ));
+    await tester.pump();
+    onResult(stt.SpeechRecognitionResult('verifie mes ingredients', true));
+    await tester.pumpAndSettle();
+    expect(observer.pushedRoutes.length, 2); // new route pushed
+  });
+}
+
+class TestNavigatorObserver extends NavigatorObserver {
+  final List<String> pushedRoutes = [];
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRoutes.add(route.settings.name ?? '');
+    super.didPush(route, previousRoute);
+  }
+}

--- a/test/screens/recipe_list_screen_semantic_test.dart
+++ b/test/screens/recipe_list_screen_semantic_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import 'package:chefito/screens/recipe_list_screen_semantic.dart';
+import 'package:chefito/services/recipe_api_service_semantic.dart';
+import 'package:chefito/models/recipe_semantic.dart';
+import 'package:chefito/services/recipe_api_service_semantic.dart' show ApiException;
+
+class MockService extends Mock implements RecipeApiServiceSemantic {}
+
+void main() {
+  testWidgets('shows loading indicator', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipes()).thenAnswer((_) async => []);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RecipeListScreenSemantic(apiService: service),
+      ),
+    );
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('shows recipes when loaded', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipes()).thenAnswer((_) async => [
+          Recipe(
+            recipeId: '1',
+            title: 'R',
+            description: 'D',
+            ingredients: [],
+            instructions: [],
+            variations: [],
+            chefGuidance: [],
+            aiConversationPrompts: [],
+            storageAndReheating: StorageAndReheating(
+              refrigeratorStorage:
+                  StoragePeriod(duration: 1, instructions: ''),
+              freezerStorage: StoragePeriod(duration: 1, instructions: ''),
+              reheatingInstructions: '',
+            ),
+            commonTroubleshooting: [],
+            successMetrics: SuccessMetrics(
+                visualCues: '',
+                textureGoal: '',
+                flavorProfile: '',
+                aromaIndicators: ''),
+            prepTimeMinutes: null,
+            cookTimeMinutes: null,
+            servings: null,
+            tags: [],
+          )
+        ]);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RecipeListScreenSemantic(apiService: service),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('R'), findsOneWidget);
+  });
+
+  testWidgets('shows error message on failure', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipes()).thenThrow(ApiException('fail'));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: RecipeListScreenSemantic(apiService: service),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.textContaining('fail'), findsOneWidget);
+    expect(find.text('Réessayer'), findsOneWidget);
+  });
+
+  testWidgets('taps recipe navigates', (tester) async {
+    final service = MockService();
+    when(service.fetchRecipes()).thenAnswer((_) async => [
+          Recipe(
+            recipeId: '1',
+            title: 'R',
+            description: 'D',
+            ingredients: [],
+            instructions: [],
+            variations: [],
+            chefGuidance: [],
+            aiConversationPrompts: [],
+            storageAndReheating: StorageAndReheating(
+              refrigeratorStorage:
+                  StoragePeriod(duration: 1, instructions: ''),
+              freezerStorage: StoragePeriod(duration: 1, instructions: ''),
+              reheatingInstructions: '',
+            ),
+            commonTroubleshooting: [],
+            successMetrics: SuccessMetrics(
+                visualCues: '',
+                textureGoal: '',
+                flavorProfile: '',
+                aromaIndicators: ''),
+            prepTimeMinutes: null,
+            cookTimeMinutes: null,
+            servings: null,
+            tags: [],
+          )
+        ]);
+    final observer = TestNavigatorObserver();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorObservers: [observer],
+        routes: {
+          '/recipe/1': (_) => const Scaffold(body: Text('detail')),
+        },
+        home: RecipeListScreenSemantic(apiService: service),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.text('R'));
+    await tester.pumpAndSettle();
+    expect(observer.pushedRoutes.contains('/recipe/1'), isTrue);
+  });
+}
+
+class TestNavigatorObserver extends NavigatorObserver {
+  final List<String> pushedRoutes = [];
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushedRoutes.add(route.settings.name ?? '');
+    super.didPush(route, previousRoute);
+  }
+}

--- a/test/services/recipe_api_service_semantic_test.dart
+++ b/test/services/recipe_api_service_semantic_test.dart
@@ -1,0 +1,176 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:chefito/services/recipe_api_service_semantic.dart';
+import 'package:chefito/models/recipe_semantic.dart';
+import 'package:chefito/models/recognition_result.dart';
+
+class MockClient extends Mock implements http.Client {}
+
+void main() {
+  group('RecipeApiServiceSemantic', () {
+    late MockClient client;
+    late RecipeApiServiceSemantic service;
+
+    setUp(() {
+      client = MockClient();
+      service = RecipeApiServiceSemantic(baseUrl: 'http://example.com', client: client);
+    });
+
+    test('fetchRecipes returns list on success', () async {
+      final sample = [
+        {
+          'recipe_id': '1',
+          'title': 'T',
+          'description': 'D',
+          'ingredients': [],
+          'instructions': [],
+          'variations': [],
+          'chef_guidance': [],
+          'ai_conversation_prompts': [],
+          'storage_and_reheating': {
+            'refrigerator_storage': {'duration': 1, 'instructions': ''},
+            'freezer_storage': {'duration': 1, 'instructions': ''},
+            'reheating_instructions': ''
+          },
+          'common_troubleshooting': [],
+          'success_metrics': {
+            'visual_cues': '',
+            'texture_goal': '',
+            'flavor_profile': '',
+            'aroma_indicators': ''
+          },
+          'tags': []
+        }
+      ];
+      when(client.get(Uri.parse('http://example.com/recipes')))
+          .thenAnswer((_) async => http.Response(json.encode(sample), 200));
+
+      final recipes = await service.fetchRecipes();
+      expect(recipes, hasLength(1));
+      expect(recipes.first.title, 'T');
+    });
+
+    test('fetchRecipes throws on failure', () async {
+      when(client.get(Uri.parse('http://example.com/recipes')))
+          .thenAnswer((_) async => http.Response('error', 500));
+
+      expect(service.fetchRecipes(), throwsA(isA<ApiException>()));
+    });
+
+    test('fetchRecipe returns single recipe', () async {
+      final sample = {
+        'recipe_id': '1',
+        'title': 'T',
+        'description': 'D',
+        'ingredients': [],
+        'instructions': [],
+        'variations': [],
+        'chef_guidance': [],
+        'ai_conversation_prompts': [],
+        'storage_and_reheating': {
+          'refrigerator_storage': {'duration': 1, 'instructions': ''},
+          'freezer_storage': {'duration': 1, 'instructions': ''},
+          'reheating_instructions': ''
+        },
+        'common_troubleshooting': [],
+        'success_metrics': {
+          'visual_cues': '',
+          'texture_goal': '',
+          'flavor_profile': '',
+          'aroma_indicators': ''
+        },
+        'tags': []
+      };
+      when(client.get(Uri.parse('http://example.com/recipes/1')))
+          .thenAnswer((_) async => http.Response(json.encode(sample), 200));
+
+      final recipe = await service.fetchRecipe('1');
+      expect(recipe.recipeId, '1');
+    });
+
+    test('fetchRecipe throws on failure', () async {
+      when(client.get(Uri.parse('http://example.com/recipes/1')))
+          .thenAnswer((_) async => http.Response('err', 404));
+
+      expect(service.fetchRecipe('1'), throwsA(isA<ApiException>()));
+    });
+
+    test('adaptRecipe returns response on success', () async {
+      final sampleRecipe = {
+        'recipe_id': '1',
+        'title': 'T',
+        'description': 'D',
+        'ingredients': [],
+        'instructions': [],
+        'variations': [],
+        'chef_guidance': [],
+        'ai_conversation_prompts': [],
+        'storage_and_reheating': {
+          'refrigerator_storage': {'duration': 1, 'instructions': ''},
+          'freezer_storage': {'duration': 1, 'instructions': ''},
+          'reheating_instructions': ''
+        },
+        'common_troubleshooting': [],
+        'success_metrics': {
+          'visual_cues': '',
+          'texture_goal': '',
+          'flavor_profile': '',
+          'aroma_indicators': ''
+        },
+        'tags': []
+      };
+      final resp = {
+        'original_recipe_id': '1',
+        'constraint_applied': "pas d'oeufs",
+        'suggested_changes_text': ['replace eggs'],
+        'adapted_recipe': sampleRecipe
+      };
+      when(client.post(Uri.parse('http://example.com/recipes/1/adapt'),
+              headers: anyNamed('headers'), body: anyNamed('body')))
+          .thenAnswer((_) async => http.Response(json.encode(resp), 200));
+
+      final result =
+          await service.adaptRecipe('1', "pas d'oeufs");
+      expect(result.constraintApplied, "pas d'oeufs");
+    });
+
+    test('adaptRecipe throws on failure', () async {
+      when(client.post(Uri.parse('http://example.com/recipes/1/adapt'),
+              headers: anyNamed('headers'), body: anyNamed('body')))
+          .thenAnswer((_) async => http.Response('err', 500));
+
+      expect(service.adaptRecipe('1', 'c'), throwsA(isA<ApiException>()));
+    });
+
+    test('recognizeIngredients parses response', () async {
+      final resp = {
+        'recognized_items': [
+          {
+            'name': 'tomate',
+            'confidence': 0.8,
+            'visual_description': 'rouge',
+            'tactile_description': 'lisse',
+            'olfactory_description': 'sucrée'
+          }
+        ]
+      };
+      when(client.send(any)).thenAnswer((_) async => http.StreamedResponse(
+          Stream.value(utf8.encode(json.encode(resp))), 200));
+      final file = File('dummy');
+      final result = await service.recognizeIngredients(file);
+      expect(result.recognizedItems.first.name, 'tomate');
+    });
+
+    test('recognizeIngredients throws on server error', () async {
+      when(client.send(any)).thenAnswer((_) async =>
+          http.StreamedResponse(Stream.value([]), 500));
+      final file = File('dummy');
+      expect(service.recognizeIngredients(file), throwsA(isA<ApiException>()));
+    });
+  });
+}

--- a/tests/api/test_ingredient_recognition_api.py
+++ b/tests/api/test_ingredient_recognition_api.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from io import BytesIO
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from app.api import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    return TestClient(app)
+
+
+def create_test_image(color='red') -> bytes:
+    img = Image.new('RGB', (10, 10), color=color)
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    return buf.getvalue()
+
+
+def test_recognize_red_image(client):
+    img_bytes = create_test_image('red')
+    files = {'file': ('img.png', img_bytes, 'image/png')}
+    res = client.post('/ingredients/recognize', files=files)
+    assert res.status_code == 200
+    names = [item['name'] for item in res.json()['recognized_items']]
+    assert 'tomate' in names
+
+
+def test_recognize_orange_image(client):
+    img_bytes = create_test_image('orange')
+    files = {'file': ('img.png', img_bytes, 'image/png')}
+    res = client.post('/ingredients/recognize', files=files)
+    assert res.status_code == 200
+    names = [item['name'] for item in res.json()['recognized_items']]
+    assert 'carotte' in names
+
+
+def test_invalid_file_type(client):
+    files = {'file': ('note.txt', b'hello', 'text/plain')}
+    res = client.post('/ingredients/recognize', files=files)
+    assert res.status_code == 415

--- a/tests/api/test_ingredient_recognition_semantic_api.py
+++ b/tests/api/test_ingredient_recognition_semantic_api.py
@@ -1,0 +1,47 @@
+import os
+import sys
+from io import BytesIO
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from app.api import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    return TestClient(app)
+
+
+def create_test_image(color='orange') -> bytes:
+    img = Image.new('RGB', (10, 10), color=color)
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    return buf.getvalue()
+
+
+def test_recognize_valid_image(client):
+    img_bytes = create_test_image()
+    files = {'file': ('image.png', img_bytes, 'image/png')}
+    res = client.post('/ingredients/recognize', files=files)
+    assert res.status_code == 200
+    data = res.json()
+    assert data['recognized_items']
+    assert data['recognized_items'][0]['name'] == 'carotte'
+
+
+def test_recognize_invalid_file(client):
+    files = {'file': ('note.txt', b'not an image', 'text/plain')}
+    res = client.post('/ingredients/recognize', files=files)
+    assert res.status_code == 415
+
+
+def test_recognize_corrupted_image(client):
+    files = {'file': ('image.png', b'badbytes', 'image/png')}
+    res = client.post('/ingredients/recognize', files=files)
+    assert res.status_code == 422
+

--- a/tests/api/test_recipe_adaptation_semantic_api.py
+++ b/tests/api/test_recipe_adaptation_semantic_api.py
@@ -1,0 +1,137 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+import pytest
+
+sys.path.insert(0, os.path.abspath('.'))
+
+from app.api.recipes_semantic import _mock_semantic_recipes_db
+from app.api import create_app
+from app.models.recipe_semantic import Recipe
+
+
+base_recipe = {
+    'recipe_id': '1111-2222',
+    'title': 'Cake',
+    'description': 'Test cake',
+    'ingredients': [
+        {
+            'id': '1',
+            'name': 'Flour',
+            'quantity': 2.0,
+            'unit': 'cups',
+            'category': 'Grain',
+            'notes': ''
+        },
+        {
+            'id': '2',
+            'name': 'Eggs',
+            'quantity': 2,
+            'unit': 'pcs',
+            'category': 'Dairy',
+            'notes': ''
+        },
+        {
+            'id': '3',
+            'name': 'Milk',
+            'quantity': 1,
+            'unit': 'cup',
+            'category': 'Dairy',
+            'notes': ''
+        }
+    ],
+    'instructions': [
+        {
+            'id': 'i1',
+            'action': 'M\u00e9langer',
+            'details': 'M\u00e9langer les \u0153ufs et la farine',
+            'time_minutes': 5,
+            'safety_warning': None,
+            'priority': 'high',
+            'ingredients_used': ['1', '2'],
+            'utensils_used': ['bowl'],
+            'troubleshooting': []
+        },
+        {
+            'id': 'i2',
+            'action': 'Cuire au four',
+            'details': 'Mettre au four pendant 20 minutes',
+            'time_minutes': 20,
+            'safety_warning': None,
+            'priority': 'medium',
+            'ingredients_used': ['1', '2', '3'],
+            'utensils_used': ['oven'],
+            'troubleshooting': []
+        }
+    ],
+    'variations': [],
+    'chef_guidance': [],
+    'ai_conversation_prompts': [],
+    'storage_and_reheating': {
+        'refrigerator_storage': {'duration': 1, 'instructions': ''},
+        'freezer_storage': {'duration': 1, 'instructions': ''},
+        'reheating_instructions': ''
+    },
+    'common_troubleshooting': [],
+    'success_metrics': {
+        'visual_cues': '',
+        'texture_goal': '',
+        'flavor_profile': '',
+        'aroma_indicators': ''
+    },
+    'prep_time_minutes': 5,
+    'cook_time_minutes': 20,
+    'servings': 2,
+    'tags': []
+}
+
+@pytest.fixture
+def client():
+    app = create_app()
+    return TestClient(app)
+
+@pytest.fixture(autouse=True)
+def clear_db():
+    _mock_semantic_recipes_db.clear()
+    yield
+    _mock_semantic_recipes_db.clear()
+
+
+def test_no_eggs_adaptation(client):
+    sample = Recipe(**base_recipe)
+    _mock_semantic_recipes_db.append(sample)
+    res = client.post(f"/recipes/{sample.recipe_id}/adapt", json={"constraint": "pas d'oeufs"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data['constraint_applied'] == "pas d'oeufs"
+    assert any('banane' in s or 'graines de lin' in s for s in data['suggested_changes_text'])
+    assert any('Substitut' in ing['name'] for ing in data['adapted_recipe']['ingredients'])
+
+
+def test_no_oven_adaptation(client):
+    sample = Recipe(**base_recipe)
+    _mock_semantic_recipes_db.append(sample)
+    res = client.post(f"/recipes/{sample.recipe_id}/adapt", json={"constraint": "pas de four"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data['constraint_applied'] == 'pas de four'
+    assert any('po\u00eale' in s for s in data['suggested_changes_text'])
+    assert any('po\u00eale' in instr['details'] for instr in data['adapted_recipe']['instructions'])
+
+
+def test_lactose_free_adaptation(client):
+    sample = Recipe(**base_recipe)
+    _mock_semantic_recipes_db.append(sample)
+    res = client.post(f"/recipes/{sample.recipe_id}/adapt", json={"constraint": "sans lactose"})
+    assert res.status_code == 200
+    data = res.json()
+    assert data['constraint_applied'] == 'sans lactose'
+    assert any('sans lactose' in ing['name'] for ing in data['adapted_recipe']['ingredients'])
+
+
+def test_unknown_constraint(client):
+    sample = Recipe(**base_recipe)
+    _mock_semantic_recipes_db.append(sample)
+    res = client.post(f"/recipes/{sample.recipe_id}/adapt", json={"constraint": "inconnu"})
+    assert res.status_code == 400
+

--- a/tests/api/test_recipes_semantic_api.py
+++ b/tests/api/test_recipes_semantic_api.py
@@ -1,0 +1,162 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+import pytest
+
+sys.path.insert(0, os.path.abspath('.'))
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+from app.database import Base, engine, SessionLocal
+from app.api import create_app
+from app.models.recipe_semantic import RecipeDB, Recipe
+
+valid_recipe = {
+    'recipe_id': '123e4567-e89b-12d3-a456-426614174000',
+    'title': 'Test Recipe',
+    'description': 'A simple test recipe',
+    'ingredients': [
+        {
+            'id': '1',
+            'name': 'Flour',
+            'quantity': 2.0,
+            'unit': 'cups',
+            'category': 'Grain',
+            'notes': 'Use all-purpose flour'
+        }
+    ],
+    'instructions': [
+        {
+            'id': 'step1',
+            'action': 'Mix',
+            'details': 'Mix all ingredients',
+            'time_minutes': 5,
+            'safety_warning': None,
+            'priority': 'high',
+            'ingredients_used': ['1'],
+            'utensils_used': ['bowl'],
+            'troubleshooting': [
+                {
+                    'problem': 'Too dry',
+                    'solution': 'Add water',
+                    'sensory_cue': 'crumbly'
+                }
+            ]
+        }
+    ],
+    'variations': ['Add vanilla'],
+    'chef_guidance': ['Be gentle'],
+    'ai_conversation_prompts': ['How do I mix?'],
+    'storage_and_reheating': {
+        'refrigerator_storage': {
+            'duration': 3,
+            'instructions': 'Store covered'
+        },
+        'freezer_storage': {
+            'duration': 1,
+            'instructions': 'Freeze tightly'
+        },
+        'reheating_instructions': 'Microwave for 1 min'
+    },
+    'common_troubleshooting': [
+        {
+            'problem': 'Burnt',
+            'solution': 'Lower heat',
+            'sensory_cue': 'smell'
+        }
+    ],
+    'success_metrics': {
+        'visual_cues': 'Golden brown',
+        'texture_goal': 'Soft',
+        'flavor_profile': 'Sweet',
+        'aroma_indicators': 'Pleasant'
+    },
+    'prep_time_minutes': 10,
+    'cook_time_minutes': 20,
+    'servings': 4,
+    'tags': ['dessert']
+}
+
+@pytest.fixture
+def client():
+    app = create_app()
+    return TestClient(app)
+
+@pytest.fixture(autouse=True)
+def prepare_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+def test_get_recipes_pagination(client):
+    session = SessionLocal()
+    for _ in range(3):
+        db_recipe = RecipeDB(
+            recipe_id=str(_),
+            title="T",
+            description="D",
+            variations=[],
+            chef_guidance=[],
+            ai_conversation_prompts=[],
+            storage_and_reheating={},
+            common_troubleshooting=[],
+            success_metrics={},
+        )
+        session.add(db_recipe)
+    session.commit()
+    session.close()
+
+    res = client.get('/recipes?skip=1&limit=1')
+    assert res.status_code == 200
+    assert len(res.json()) == 1
+
+
+def test_get_recipe_by_id(client):
+    session = SessionLocal()
+    db_recipe = RecipeDB(
+        recipe_id="abc",
+        title="T",
+        description="D",
+        variations=[],
+        chef_guidance=[],
+        ai_conversation_prompts=[],
+        storage_and_reheating={},
+        common_troubleshooting=[],
+        success_metrics={},
+    )
+    session.add(db_recipe)
+    session.commit()
+    session.close()
+
+    res = client.get(f'/recipes/{db_recipe.recipe_id}')
+    assert res.status_code == 200
+    assert res.json()['recipe_id'] == db_recipe.recipe_id
+
+
+def test_get_recipe_not_found(client):
+    res = client.get('/recipes/nonexistent')
+    assert res.status_code == 404
+
+
+def test_create_recipe(client):
+    payload = valid_recipe.copy()
+    payload.pop('recipe_id')
+
+    res = client.post('/recipes', json=payload)
+    assert res.status_code == 201
+    data = res.json()
+    assert data['recipe_id']
+    session = SessionLocal()
+    count = session.query(RecipeDB).count()
+    session.close()
+    assert count == 1
+
+
+def test_create_recipe_invalid(client):
+    payload = valid_recipe.copy()
+    payload.pop('recipe_id')
+    payload.pop('title')
+
+    res = client.post('/recipes', json=payload)
+    assert res.status_code == 422

--- a/tests/models/recipe_semantic_model_test.py
+++ b/tests/models/recipe_semantic_model_test.py
@@ -1,0 +1,84 @@
+import os, sys
+sys.path.insert(0, os.path.abspath("."))
+import pytest
+from app.models.recipe_semantic import Recipe, Ingredient, Instruction, TroubleshootingTip, StoragePeriod, StorageAndReheating, SuccessMetrics
+
+valid_recipe = {
+    'recipe_id': '123e4567-e89b-12d3-a456-426614174000',
+    'title': 'Test Recipe',
+    'description': 'A simple test recipe',
+    'ingredients': [
+        {
+            'id': '1',
+            'name': 'Flour',
+            'quantity': 2.0,
+            'unit': 'cups',
+            'category': 'Grain',
+            'notes': 'Use all-purpose flour'
+        }
+    ],
+    'instructions': [
+        {
+            'id': 'step1',
+            'action': 'Mix',
+            'details': 'Mix all ingredients',
+            'time_minutes': 5,
+            'safety_warning': None,
+            'priority': 'high',
+            'ingredients_used': ['1'],
+            'utensils_used': ['bowl'],
+            'troubleshooting': [
+                {
+                    'problem': 'Too dry',
+                    'solution': 'Add water',
+                    'sensory_cue': 'crumbly'
+                }
+            ]
+        }
+    ],
+    'variations': ['Add vanilla'],
+    'chef_guidance': ['Be gentle'],
+    'ai_conversation_prompts': ['How do I mix?'],
+    'storage_and_reheating': {
+        'refrigerator_storage': {
+            'duration': 3,
+            'instructions': 'Store covered'
+        },
+        'freezer_storage': {
+            'duration': 1,
+            'instructions': 'Freeze tightly'
+        },
+        'reheating_instructions': 'Microwave for 1 min'
+    },
+    'common_troubleshooting': [
+        {
+            'problem': 'Burnt',
+            'solution': 'Lower heat',
+            'sensory_cue': 'smell'
+        }
+    ],
+    'success_metrics': {
+        'visual_cues': 'Golden brown',
+        'texture_goal': 'Soft',
+        'flavor_profile': 'Sweet',
+        'aroma_indicators': 'Pleasant'
+    },
+    'prep_time_minutes': 10,
+    'cook_time_minutes': 20,
+    'servings': 4,
+    'tags': ['dessert']
+}
+
+invalid_recipe = valid_recipe.copy()
+invalid_recipe.pop('title')
+
+
+def test_valid_recipe_parses():
+    recipe = Recipe(**valid_recipe)
+    assert recipe.title == 'Test Recipe'
+
+
+def test_invalid_recipe_fails():
+    with pytest.raises(Exception):
+        Recipe(**invalid_recipe)
+


### PR DESCRIPTION
## Summary
- implement a simple ingredient recognition router
- wire the router into the FastAPI application
- test recognition of red/orange images and wrong media type
- add ingredient recognition service and Flutter UI screen
- support voice command to launch ingredient recognition

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `dart test` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686ee45d320083259fa40ad5003f929e